### PR TITLE
Add accountNumber and sortCode length validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,6 +199,10 @@ export default class UkModulusChecking {
    */
 
    isValid() {
+     if (this.accountNumber.length < 6 || this.accountNumber.length > 10 || this.sortCode.length !== 6) {
+       return false;
+     }
+
      const checks = this.getSortCodeChecks();
 
      // If no range is found that contains the sorting code, there is no modulus check that can be performed.

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -52,6 +52,18 @@ const accounts = {
 
 describe('UkModulusChecking', () => {
   describe('isValid()', () => {
+    it('should return false if account number length is less than 6', () => {
+      new UkModulusChecking({ accountNumber: '12345', sortCode: '123456' }).isValid().should.be.false();
+    });
+
+    it('should return false if account number length is greater than 10', () => {
+      new UkModulusChecking({ accountNumber: '12345678901', sortCode: '123456' }).isValid().should.be.false();
+    });
+
+    it('should return false if sort code length is not 6', () => {
+      new UkModulusChecking({ accountNumber: '12345789', sortCode: '12345' }).isValid().should.be.false();
+    });
+
     accounts.invalid.forEach((account) => {
       it(`should return false if sort code is ${account.sortCode} and account number is ${account.accountNumber}`, () => {
         new UkModulusChecking({ accountNumber: account.accountNumber, sortCode: account.sortCode }).isValid().should.be.false();


### PR DESCRIPTION
This PR adds `accountNumber` and `sortCode` length validation after sanitisation.

The `sortCode` must have 6 digits. The `accountNumber` must have 6 to 10 digits.