### PR TITLE
Add `babel-plugin-static-fs`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "plugins": ["add-module-exports"],
+  "plugins": ["add-module-exports", "static-fs"],
   "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepublish": "npm run transpile",
     "testdocker": "docker-compose run --rm sut",
     "test": "mocha $npm_package_options_mocha",
-    "transpile": "rm -rf dist/* && babel src --out-dir dist && cp -r src/data dist",
+    "transpile": "rm -rf dist/* && babel src --out-dir dist",
     "version": "npm run changelog -- --future-release=$npm_package_version && sed -i '' -e :a -e '$d;N;2,3ba' -e 'P;D' CHANGELOG.md && npm run transpile && git add -A CHANGELOG.md dist"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-cli": "^6.4.0",
     "babel-eslint": "^4.1.6",
     "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-static-fs": "^1.2.0",
     "babel-preset-es2015": "6.5.0",
     "babel-register": "^6.3.13",
     "eslint": "^1.10.3",


### PR DESCRIPTION
Adds a babel plugin that inlines calls to `fs.readFileSync()` thus making it possible to use `uk-modulus-checking` in a browser environment (with your choice of bundler of course).

Fixes #11.
Fixes #12.